### PR TITLE
Pal 514 refactor launcher application yaml

### DIFF
--- a/audit-service/pom.xml
+++ b/audit-service/pom.xml
@@ -226,6 +226,9 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <layout>ZIP</layout>
+                </configuration>
                 <executions>
                     <execution>
                         <id>repackage</id>

--- a/data-service/pom.xml
+++ b/data-service/pom.xml
@@ -263,6 +263,9 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <layout>ZIP</layout>
+                </configuration>
                 <executions>
                     <execution>
                         <id>repackage</id>

--- a/palisade-service/pom.xml
+++ b/palisade-service/pom.xml
@@ -256,6 +256,9 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <layout>ZIP</layout>
+                </configuration>
                 <executions>
                     <execution>
                         <id>repackage</id>

--- a/policy-service/pom.xml
+++ b/policy-service/pom.xml
@@ -259,6 +259,9 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <layout>ZIP</layout>
+                </configuration>
                 <executions>
                     <execution>
                         <id>repackage</id>

--- a/policy-service/src/main/java/uk/gov/gchq/palisade/service/policy/PolicyApplication.java
+++ b/policy-service/src/main/java/uk/gov/gchq/palisade/service/policy/PolicyApplication.java
@@ -33,7 +33,7 @@ public class PolicyApplication {
     private static final Logger LOGGER = LoggerFactory.getLogger(PolicyApplication.class);
 
     public static void main(final String[] args) {
-        LOGGER.debug("PolicyApplication started with: {}", PolicyApplication.class.toString(), "main", Arrays.toString(args));
+        LOGGER.debug("PolicyApplication started with: {} {} {}", PolicyApplication.class.toString(), "main", Arrays.toString(args));
         new SpringApplicationBuilder(PolicyApplication.class).web(WebApplicationType.SERVLET)
                 .run(args);
     }

--- a/resource-service/pom.xml
+++ b/resource-service/pom.xml
@@ -238,6 +238,9 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <layout>ZIP</layout>
+                </configuration>
                 <executions>
                     <execution>
                         <id>repackage</id>

--- a/services-launcher/src/main/java/uk/gov/gchq/palisade/service/launcher/config/ApplicationConfiguration.java
+++ b/services-launcher/src/main/java/uk/gov/gchq/palisade/service/launcher/config/ApplicationConfiguration.java
@@ -73,11 +73,9 @@ public class ApplicationConfiguration {
                     ServiceConfiguration config = e.getValue();
                     String[] command = new String[] {
                             JavaEnvUtils.getJreExecutable("java"),
-                            "-cp", config.getClasspath(),
-                            String.format("-Dspring.config.location=%s", config.getConfig()),
+                            String.format("-Dloader.path=%s", config.getPath()),
                             String.format("-Dspring.profiles.active=%s", config.getProfiles()),
-                            String.format("-Dloader.main=%s", config.getMain()),
-                            config.getLauncher()
+                            "-jar", config.getClasspath()
                     };
                     ProcessBuilder pb = new ProcessBuilder()
                             .command(command)

--- a/services-launcher/src/main/java/uk/gov/gchq/palisade/service/launcher/config/ServiceConfiguration.java
+++ b/services-launcher/src/main/java/uk/gov/gchq/palisade/service/launcher/config/ServiceConfiguration.java
@@ -19,11 +19,9 @@ package uk.gov.gchq.palisade.service.launcher.config;
 public class ServiceConfiguration {
 
     private String classpath;
-    private String config;
-    private String launcher;
-    private String main;
-    private String profiles;
+    private String path;
     private String log;
+    private String profiles;
 
     public String getClasspath() {
         return classpath;
@@ -31,30 +29,6 @@ public class ServiceConfiguration {
 
     public void setClasspath(final String classpath) {
         this.classpath = classpath;
-    }
-
-    public String getConfig() {
-        return config;
-    }
-
-    public void setConfig(final String config) {
-        this.config = config;
-    }
-
-    public String getLauncher() {
-        return launcher;
-    }
-
-    public void setLauncher(final String launcher) {
-        this.launcher = launcher;
-    }
-
-    public String getMain() {
-        return main;
-    }
-
-    public void setMain(final String main) {
-        this.main = main;
     }
 
     public String getProfiles() {
@@ -73,4 +47,11 @@ public class ServiceConfiguration {
         this.log = log;
     }
 
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(final String path) {
+        this.path = path;
+    }
 }

--- a/services-launcher/src/main/resources/application.yaml
+++ b/services-launcher/src/main/resources/application.yaml
@@ -30,56 +30,42 @@ app:
 launcher:
   # search up path for a named root directory
   root: palisade-services
-  # library root relative to launcher.root above
-  library-root: ../palisade-examples/example-library
-  # java -cp [..]policy-service.jar:[...]example-library.jar -Dspring.config.location=policy-service/target/classes/ -Dspring.profiles.active=jvm, -Dloader.main=[...].PolicyApplication [...].JarLauncher
+  # library relative to launcher.root above
+  example-library: ../palisade-examples/example-library/target/
+  # java -Dloader.path=[...]policy-service-jar-with-dependencies.jar,[...]example-library-jar-with-dependencies.jar -Dspring.profiles.active=jvm -jar [...]policy-service-exec.jar
   services:
     audit-service:
-      classpath: audit-service/target/audit-service-${app.version}-exec.jar:${launcher.library-root}/target/example-library-0.4.0-SNAPSHOT-jar-with-dependencies.jar
-      config: audit-service/target/classes/
-      launcher: org.springframework.boot.loader.JarLauncher
-      main: uk.gov.gchq.palisade.service.audit.AuditApplication
+      classpath: audit-service/target/audit-service-${app.version}-exec.jar
+      path: ${launcher.example-library}
       profiles: default
       log: audit-service.log
     data-service:
-      classpath: data-service/target/data-service-${app.version}-exec.jar:${launcher.library-root}/target/example-library-0.4.0-SNAPSHOT-jar-with-dependencies.jar
-      config: data-service/target/classes/
-      launcher: org.springframework.boot.loader.JarLauncher
-      main: uk.gov.gchq.palisade.service.data.DataApplication
+      classpath: data-service/target/data-service-${app.version}-exec.jar
+      path: ${launcher.example-library}
       profiles: default
       log: data-service.log
     discovery-service:
       classpath: discovery-service/target/discovery-service-${app.version}-exec.jar
-      config: discovery-service/target/classes/
-      launcher: org.springframework.boot.loader.JarLauncher
-      main: uk.gov.gchq.palisade.service.discovery.DiscoveryApplication
+      path:
       profiles: default
       log: discovery-service.log
     palisade-service:
-      classpath: palisade-service/target/palisade-service-${app.version}-exec.jar:${launcher.library-root}/target/example-library-0.4.0-SNAPSHOT-jar-with-dependencies.jar
-      config: palisade-service/target/classes/
-      launcher: org.springframework.boot.loader.JarLauncher
-      main: uk.gov.gchq.palisade.service.palisade.PalisadeApplication
+      classpath: palisade-service/target/palisade-service-${app.version}-exec.jar
+      path: ${launcher.example-library}
       profiles: default
       log: palisade-service.log
     policy-service:
-      classpath: policy-service/target/policy-service-${app.version}-exec.jar:${launcher.library-root}/target/example-library-0.4.0-SNAPSHOT-jar-with-dependencies.jar
-      config: policy-service/target/classes/
-      launcher: org.springframework.boot.loader.JarLauncher
-      main: uk.gov.gchq.palisade.service.policy.PolicyApplication
+      classpath: policy-service/target/policy-service-${app.version}-exec.jar
+      path: ${launcher.example-library}
       profiles: default
       log: policy-service.log
     resource-service:
       classpath: resource-service/target/resource-service-${app.version}-exec.jar
-      config: resource-service/target/classes/
-      launcher: org.springframework.boot.loader.JarLauncher
-      main: uk.gov.gchq.palisade.service.resource.ResourceApplication
+      path:
       profiles: default
       log: resource-service.log
     user-service:
-      classpath: user-service/target/user-service-${app.version}-exec.jar:${launcher.library-root}/target/example-library-0.4.0-SNAPSHOT-jar-with-dependencies.jar
-      config: user-service/target/classes/
-      launcher: org.springframework.boot.loader.JarLauncher
-      main: uk.gov.gchq.palisade.service.user.UserApplication
+      classpath: user-service/target/user-service-${app.version}-exec.jar
+      path: ${launcher.example-library}
       profiles: default
       log: user-service.log

--- a/user-service/mvn_dependency_tree.txt
+++ b/user-service/mvn_dependency_tree.txt
@@ -52,6 +52,37 @@ uk.gov.gchq.palisade:user-service:jar:0.4.0-SNAPSHOT
 |  +- org.springframework.cloud:spring-cloud-context:jar:2.2.0.RELEASE:compile
 |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.10.0:compile
 |  \- com.fasterxml.jackson.core:jackson-databind:jar:2.10.0:compile
++- com.netflix.eureka:eureka-client:jar:1.9.13:compile
+|  +- org.codehaus.jettison:jettison:jar:1.3.7:runtime
+|  |  \- stax:stax-api:jar:1.0.1:runtime
+|  +- com.netflix.netflix-commons:netflix-eventbus:jar:0.3.0:runtime
+|  |  +- com.netflix.netflix-commons:netflix-infix:jar:0.3.0:runtime
+|  |  |  +- commons-jxpath:commons-jxpath:jar:1.3:runtime
+|  |  |  +- joda-time:joda-time:jar:2.10.4:runtime
+|  |  |  +- org.antlr:antlr-runtime:jar:3.4:runtime
+|  |  |  |  +- org.antlr:stringtemplate:jar:3.2.1:runtime
+|  |  |  |  \- antlr:antlr:jar:2.7.7:runtime
+|  |  |  \- com.google.code.gson:gson:jar:2.8.6:runtime
+|  |  \- org.apache.commons:commons-math:jar:2.2:runtime
+|  +- com.thoughtworks.xstream:xstream:jar:1.4.11.1:runtime
+|  |  +- xmlpull:xmlpull:jar:1.1.3.1:runtime
+|  |  \- xpp3:xpp3_min:jar:1.1.4c:runtime
+|  +- com.netflix.archaius:archaius-core:jar:0.7.6:compile
+|  |  +- commons-configuration:commons-configuration:jar:1.8:compile
+|  |  |  \- commons-lang:commons-lang:jar:2.6:compile
+|  |  \- com.google.guava:guava:jar:16.0:runtime
+|  +- javax.ws.rs:jsr311-api:jar:1.1.1:runtime
+|  +- com.netflix.servo:servo-core:jar:0.12.21:runtime
+|  +- com.sun.jersey:jersey-core:jar:1.19.1:runtime
+|  +- com.sun.jersey:jersey-client:jar:1.19.1:runtime
+|  +- com.sun.jersey.contribs:jersey-apache-client4:jar:1.19.1:runtime
+|  +- org.apache.httpcomponents:httpclient:jar:4.5.10:runtime
+|  |  +- org.apache.httpcomponents:httpcore:jar:4.4.12:runtime
+|  |  \- commons-codec:commons-codec:jar:1.13:runtime
+|  +- com.google.inject:guice:jar:4.1.0:runtime
+|  |  +- javax.inject:javax.inject:jar:1:runtime
+|  |  \- aopalliance:aopalliance:jar:1.0:runtime
+|  \- com.fasterxml.jackson.core:jackson-core:jar:2.10.0:compile
 +- org.springframework.cloud:spring-cloud-netflix-eureka-client:jar:2.2.0.RELEASE:compile
 |  \- org.springframework.cloud:spring-cloud-netflix-hystrix:jar:2.2.0.RELEASE:compile
 |     \- org.springframework.boot:spring-boot-starter-aop:jar:2.2.0.RELEASE:compile
@@ -70,10 +101,6 @@ uk.gov.gchq.palisade:user-service:jar:0.4.0-SNAPSHOT
 |  +- io.github.openfeign:feign-core:jar:10.4.0:compile
 |  +- io.github.openfeign:feign-slf4j:jar:10.4.0:compile
 |  \- io.github.openfeign:feign-hystrix:jar:10.4.0:compile
-|     +- com.netflix.archaius:archaius-core:jar:0.7.6:compile
-|     |  +- com.google.code.findbugs:jsr305:jar:3.0.1:runtime
-|     |  +- commons-configuration:commons-configuration:jar:1.8:compile
-|     |  \- com.google.guava:guava:jar:16.0:runtime
 |     \- com.netflix.hystrix:hystrix-core:jar:1.5.18:compile
 +- org.springframework.cloud:spring-cloud-starter-ribbon:jar:1.4.7.RELEASE:compile
 |  \- org.springframework.cloud:spring-cloud-starter-netflix-ribbon:jar:2.2.0.RELEASE:compile
@@ -82,20 +109,10 @@ uk.gov.gchq.palisade:user-service:jar:0.4.0-SNAPSHOT
 |     |  +- com.netflix.ribbon:ribbon-transport:jar:2.3.0:runtime
 |     |  |  +- io.reactivex:rxnetty-contexts:jar:0.4.9:runtime
 |     |  |  \- io.reactivex:rxnetty-servo:jar:0.4.9:runtime
-|     |  +- javax.inject:javax.inject:jar:1:runtime
 |     |  \- io.reactivex:rxnetty:jar:0.4.9:runtime
 |     +- com.netflix.ribbon:ribbon-core:jar:2.3.0:compile
-|     |  \- commons-lang:commons-lang:jar:2.6:compile
 |     +- com.netflix.ribbon:ribbon-httpclient:jar:2.3.0:compile
 |     |  +- commons-collections:commons-collections:jar:3.2.2:runtime
-|     |  +- org.apache.httpcomponents:httpclient:jar:4.5.10:runtime
-|     |  |  +- org.apache.httpcomponents:httpcore:jar:4.4.12:runtime
-|     |  |  \- commons-codec:commons-codec:jar:1.13:runtime
-|     |  +- com.sun.jersey:jersey-client:jar:1.19.1:runtime
-|     |  |  \- com.sun.jersey:jersey-core:jar:1.19.1:runtime
-|     |  |     \- javax.ws.rs:jsr311-api:jar:1.1.1:runtime
-|     |  +- com.sun.jersey.contribs:jersey-apache-client4:jar:1.19.1:runtime
-|     |  +- com.netflix.servo:servo-core:jar:0.12.21:runtime
 |     |  \- com.netflix.netflix-commons:netflix-commons-util:jar:0.3.0:runtime
 |     +- com.netflix.ribbon:ribbon-loadbalancer:jar:2.3.0:compile
 |     |  \- com.netflix.netflix-commons:netflix-statistics:jar:0.1.1:runtime
@@ -117,7 +134,6 @@ uk.gov.gchq.palisade:user-service:jar:0.4.0-SNAPSHOT
 |  |  \- com.kohlschutter.junixsocket:junixsocket-common:jar:2.0.4:compile
 |  \- net.java.dev.jna:jna-platform:jar:4.5.2:compile
 +- uk.gov.gchq.palisade:common:jar:0.4.0-SNAPSHOT:compile
-|  +- com.fasterxml.jackson.core:jackson-core:jar:2.10.0:compile
 |  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.10.0:compile
 |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.10.0:compile
 |  +- commons-io:commons-io:jar:2.6:compile

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -78,6 +78,10 @@
             <artifactId>spring-cloud-config-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.netflix.eureka</groupId>
+            <artifactId>eureka-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-netflix-eureka-client</artifactId>
         </dependency>
@@ -250,6 +254,9 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <layout>ZIP</layout>
+                </configuration>
                 <executions>
                     <execution>
                         <id>repackage</id>


### PR DESCRIPTION
Changed the launch process for the services within the services-launcher. This has been done due to the Spring and Eureka dependencies being taken from the example-library jar rather than the service exec jar using the current process.
The change for resolving this has only been added to the services that require the use of the example-library dependency jar (audit, data, palisade, policy, user).

The command for launching a service has been drastically reduced in length and now looks like this:
`java -Dloader.path=../palisade-examples/example-library/target/ -Dspring.profiles.active=jvm -jar palisade-service/target/palisade-service-0.4.0-SNAPSHOT-exec.jar`