### PR TITLE
PAL-717 Added binary switch for redis master/worker or clustered

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,16 +117,19 @@ Some more important arguments are as follows:
 | global.kafka.install                    | Install Kafka and Zookeeper, **default=true**
 | global.redis.install                    | Install Redis, **default=true**
 | global.redis-cluster.install            | Install Redis-cluster, **default=false**
+| global.redisClusterEnabled              | Set to true to use Redis cluster. Useful if redis is already installed. **default=false**
 
 #### Redis vs Redis-Cluster
+
 The key difference is scalability, write-points, sharding and partitioning.
-* Redis will support a single (master) write-point with many replicated (slave) read-points.
+* Redis will support a single (master) write-point with many replicated (worker) read-points.
 * Redis-cluster will support sharding across the keyspace such that keys are uniquely mapped to one of many partitions, each partition with a single write-point and many read-points as above.
 
 Recommended reading: [Amazon AWS documentation, Redis with Cluster Mode enabled](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Replication.Redis-RedisCluster.html)
 Redis is simpler, but will bottle-neck on write-requests to the single master node, eventually.
 
 #### Kubernetes Dashboard
+
 If the [Kubernetes dashboard](https://kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard/) is required it must be installed separately as a prerequisite.
 The `dashboard.install` switch installs ingress definitions into traefik for access at `https://localhost/kubernetes`.
 Access to the dashboard should be by token, which can be obtained by running the following command against the cluster:
@@ -135,7 +138,6 @@ kubectl -n kube-system describe secrets \
   `kubectl -n kube-system get secrets | awk '/clusterrole-aggregation-controller/ {print $1}'` \
   | awk '/token:/ {print $2}'
 ```
-
 
 ### Changing Application Logging Level
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Some more important arguments are as follows:
 | global.kafka.install                    | Install Kafka and Zookeeper, **default=true**
 | global.redis.install                    | Install Redis, **default=true**
 | global.redis-cluster.install            | Install Redis-cluster, **default=false**
-| global.redisClusterEnabled              | Set to true to use Redis cluster. Useful if redis is already installed. **default=false**
+| global.redisClusterEnabled              | Set to true to use Redis-cluster or false to use Redis. Useful if redis is already installed. **default=false**
 
 #### Redis vs Redis-Cluster
 

--- a/charts/user-service/templates/configmap.yaml
+++ b/charts/user-service/templates/configmap.yaml
@@ -25,12 +25,18 @@ metadata:
 data:
   application-redis.yaml: |  
     {{- if $.Values.global.redisClusterEnabled }}
+      {{- if $.Values.global.redis.install }}
+        {{- fail "Cannot install Redis (master/worker) if Redis Cluster is selected" }}
+      {{- end }}
     {{- $clusterNodes := include "palisade.redis-cluster.headlessNodes" . | trimAll "," }}
     spring:
       redis:
         cluster:
           nodes: {{ $clusterNodes }}
     {{- else }}
+      {{- if (index $.Values.global "redis-cluster").install }}
+        {{- fail "Cannot install Redis Cluster if Redis (master/worker) is selected" }}
+      {{- end }}
     {{- $masterFullname := printf "%s-master" (include "palisade.redis.fullname" .) }}
     {{- $masterPort := int $.Values.global.redis.master.service.port }}
     spring:

--- a/charts/user-service/templates/configmap.yaml
+++ b/charts/user-service/templates/configmap.yaml
@@ -24,6 +24,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   application-redis.yaml: |  
+    {{- if and ($.Values.global.redis.install) ((index $.Values.global "redis-cluster").install) }}
+      {{- fail "Cannot install Redis (master/worker) and Redis Cluster at the same time" }}
+    {{- end }}
     {{- if $.Values.global.redisClusterEnabled }}
       {{- if $.Values.global.redis.install }}
         {{- fail "Cannot install Redis (master/worker) if Redis Cluster is selected" }}

--- a/charts/user-service/templates/configmap.yaml
+++ b/charts/user-service/templates/configmap.yaml
@@ -23,18 +23,18 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
-  application-redis.yaml: |
-    {{- if or .Values.global.redis.install .Values.global.redis.config }}
-    {{- $masterFullname := printf "%s-master" (include "palisade.redis.fullname" .) }}
-    {{- $masterPort := int .Values.global.redis.master.service.port }}
-    spring:
-      redis:
-        host: {{ $masterFullname }}
-        port: {{ $masterPort }}
-    {{- else if or (index .Values.global "redis-cluster").install (index .Values.global "redis-cluster").config }}
+  application-redis.yaml: |  
+    {{- if $.Values.global.redisClusterEnabled }}
     {{- $clusterNodes := include "palisade.redis-cluster.headlessNodes" . | trimAll "," }}
     spring:
       redis:
         cluster:
           nodes: {{ $clusterNodes }}
+    {{- else }}
+    {{- $masterFullname := printf "%s-master" (include "palisade.redis.fullname" .) }}
+    {{- $masterPort := int $.Values.global.redis.master.service.port }}
+    spring:
+      redis:
+        host: {{ $masterFullname }}
+        port: {{ $masterPort }}
     {{- end }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -24,3 +24,13 @@ You have installed {{ .Chart.Name }} as release {{ .Release.Name }} into namespa
     {{- println }}Routing to the kubernetes dashboard is provided at (https:/) /kubernetes/#/
 {{- end }}
 {{- end }}
+
+{{- if $.Values.global.redisClusterEnabled }}
+    {{- $clusterNodes := include "palisade.redis-cluster.headlessNodes" . | trimAll "," }}
+    {{- println }}Redis is clustered using nodes: {{ $clusterNodes }}
+{{- else }}
+    {{- $masterFullname := printf "%s-master" (include "palisade.redis.fullname" .) }}
+    {{- $masterPort := int .Values.global.redis.master.service.port }}
+    {{- println }}Redis is master/worker with master at: {{ $masterFullname }}:{{ $masterPort }}
+{{- end }}
+

--- a/values.yaml
+++ b/values.yaml
@@ -42,7 +42,7 @@ global:
 
   redis:
     # install: install redis persistence and caching data storage platform
-    install: false
+    install: true
     # config: configure services to connect to (previously installed?) redis (if unset, use install value)
     # config: true
     exports:
@@ -53,7 +53,7 @@ global:
 
   redis-cluster:
     # install: install clustered redis persistence and caching data storage platform
-    install: true
+    install: false
     # config: configure services to connect to (previously installed?) redis-cluster (if unset, use install value)
     # config: false
     # imported from sub-chart, default values here are overridden by sub-chart values
@@ -67,7 +67,7 @@ global:
   hosting: local
 
   # Set to true to enable redis cluster. leave as false for master/worker
-  redisClusterEnabled: true
+  redisClusterEnabled: false
 
   # nodes: the number of nodes in the cluster, this will be used to calculate the service scaling factors
   nodes: 1

--- a/values.yaml
+++ b/values.yaml
@@ -42,7 +42,7 @@ global:
 
   redis:
     # install: install redis persistence and caching data storage platform
-    install: true
+    install: false
     # config: configure services to connect to (previously installed?) redis (if unset, use install value)
     # config: true
     exports:
@@ -53,7 +53,7 @@ global:
 
   redis-cluster:
     # install: install clustered redis persistence and caching data storage platform
-    install: false
+    install: true
     # config: configure services to connect to (previously installed?) redis-cluster (if unset, use install value)
     # config: false
     # imported from sub-chart, default values here are overridden by sub-chart values
@@ -65,6 +65,9 @@ global:
 
   # hosting: [local | aws | metal] the target environment to deploy to
   hosting: local
+
+  # Set to true to enable redis cluster. leave as false for master/worker
+  redisClusterEnabled: true
 
   # nodes: the number of nodes in the cluster, this will be used to calculate the service scaling factors
   nodes: 1


### PR DESCRIPTION
Added a binary switch that can be used to select which Redis install to use. This does not effect the installation. That is still controlled by two other switches. This enables installation of Palisade without installing any Redis types, but selecting which existing one to use.

Could devs have a look at this. I'm sure there is something missing.