### PR TITLE
Pal 718 global flag for statefulset pv/pvc(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ kubectl config use-context <name>
 Example first deployment to a local cluster (from the project root directory):
 ```  
  helm upgrade --install palisade . \
-  --set global.persistence.classpathJars.local.hostPath=$(pwd),global.persistence.dataStores.palisade-data-store.local.hostPath=$(pwd),global.persistence.kafka.local.hostPath=$(pwd),global.persistence.redisMaster.local.hostPath=$(pwd),global.persistence.redisSlave.local.hostPath=$(pwd),global.persistence.zookeeper.local.hostPath=$(pwd),traefik.install=true,kafka.install=true,redis.install=true,global.hosting=local,redis-cluster.install=false --timeout=200s
+  --set global.persistence.statefulset.pv.enabled=true,global.persistence.classpathJars.local.hostPath=$(pwd),global.persistence.dataStores.palisade-data-store.local.hostPath=$(pwd),global.persistence.kafka.local.hostPath=$(pwd),global.persistence.redisMaster.local.hostPath=$(pwd),global.persistence.redisSlave.local.hostPath=$(pwd),global.persistence.zookeeper.local.hostPath=$(pwd),traefik.install=true,kafka.install=true,redis.install=true,global.hosting=local,redis-cluster.install=false --timeout=200s
 ```
 This will deploy the traefik ingress controller and install Palisade with a deployment name of "palisade" into the default namespace.
 The application will be available at `http://localhost/palisade` and the traefik dashboard will be available at `http://localhost:8080/dashboard/#/`.

--- a/charts/kafka/charts/zookeeper/templates/zookeeper-pv.yaml
+++ b/charts/kafka/charts/zookeeper/templates/zookeeper-pv.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+{{- if .Values.global.persistence.statefulset.pv.enabled }}
 {{- $namespace := include "palisade.namespace" . }}
 {{- $zookeepername := include "zookeeper.fullname" . }}
 {{- $config := .Values.global.persistence.zookeeper }}
@@ -47,5 +47,6 @@ spec:
     volumeAttributes:
       path: {{ $config.aws.volumePath }}/zookeeper/{{ $namespace }}/{{ $index }}
   {{- end }}
+{{- end }}
 ---
 {{- end }}

--- a/charts/kafka/templates/kafka-pv.yaml
+++ b/charts/kafka/templates/kafka-pv.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+{{- if .Values.global.persistence.statefulset.pv.enabled }}
 {{- $namespace := include "palisade.namespace" . }}
 {{- $kafkaname := include "kafka.fullname" . }}
 {{- $config := .Values.global.persistence.kafka }}
@@ -48,5 +48,6 @@ spec:
       path: {{ $config.aws.volumePath }}/kafka/{{ $namespace }}/{{ $index }}
       type: DirectoryOrCreate
   {{- end }}
+{{- end }}
 ---
 {{- end }}

--- a/charts/redis/templates/redis-pv-master.yaml
+++ b/charts/redis/templates/redis-pv-master.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+{{- if .Values.global.persistence.statefulset.pv.enabled }}
 {{- $namespace := include "palisade.namespace" . }}
 {{- $redisname := include "redis.fullname" . }}
 {{- $config := $.Values.global.persistence.redisMaster }}
@@ -46,6 +46,7 @@ spec:
     volumeHandle: {{ required "A valid AWS EFS volume handle must be specified" $config.aws.volumeHandle }}
     volumeAttributes:
       path: {{ $config.aws.volumePath }}/redis/{{ $namespace }}/master/{{ $index }}
+  {{- end }}
   {{- end }}
 ---
 {{- end }}

--- a/charts/redis/templates/redis-pv-slave.yaml
+++ b/charts/redis/templates/redis-pv-slave.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+{{- if .Values.global.persistence.statefulset.pv.enabled }}
 {{- $namespace := include "palisade.namespace" . }}
 {{- $redisname := include "redis.fullname" . }}
 {{- $config := $.Values.global.persistence.redisSlave }}
@@ -47,5 +47,6 @@ spec:
     volumeAttributes:
       path: {{ $config.aws.volumePath }}/redis/{{ $namespace }}/slave/{{ $index }}
   {{- end }}
+{{- end }}
 ---
 {{- end }}

--- a/palisade-service/src/main/java/uk/gov/gchq/palisade/service/palisade/PalisadeApplication.java
+++ b/palisade-service/src/main/java/uk/gov/gchq/palisade/service/palisade/PalisadeApplication.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 public class PalisadeApplication {
     private static final Logger LOGGER = LoggerFactory.getLogger(PalisadeApplication.class);
 
+    //trivial change to test PAL-779
     public static void main(final String[] args) {
         LOGGER.debug("PalisadeApplication started with: {}", Arrays.toString(args));
 

--- a/palisade-service/src/main/java/uk/gov/gchq/palisade/service/palisade/PalisadeApplication.java
+++ b/palisade-service/src/main/java/uk/gov/gchq/palisade/service/palisade/PalisadeApplication.java
@@ -32,7 +32,6 @@ import java.util.Arrays;
 public class PalisadeApplication {
     private static final Logger LOGGER = LoggerFactory.getLogger(PalisadeApplication.class);
 
-    //trivial change to test PAL-779
     public static void main(final String[] args) {
         LOGGER.debug("PalisadeApplication started with: {}", Arrays.toString(args));
 

--- a/templates/classpath-jars-pv.yaml
+++ b/templates/classpath-jars-pv.yaml
@@ -17,6 +17,7 @@
 #the volume is actually used by other pods as a different mode
 #there is quite a good explanation here: https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/100
 #as to the slightly anomalous behaviour
+{{- if .Values.global.persistence.statefulset.pv.enabled }}
 {{- $namespace := include "palisade.namespace" . }}
 apiVersion: v1
 kind: PersistentVolume
@@ -47,4 +48,5 @@ spec:
     volumeHandle: {{ required "A valid AWS EFS volume handle must be specified" .Values.global.persistence.classpathJars.aws.volumeHandle }}
     volumeAttributes:
       path: {{ include "palisade.deployment.path" . }}
+  {{- end }}
   {{- end }}

--- a/templates/data-store-pv.yaml
+++ b/templates/data-store-pv.yaml
@@ -20,7 +20,7 @@
 # the volume is actually used by other pods as a different mode
 # there is quite a good explanation here: https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/100
 # as to the slightly anomalous behaviour
-
+{{- if .Values.global.persistence.statefulset.pv.enabled }}
 {{- $namespace := include "palisade.namespace" . }}
 {{- range $name, $value := .Values.global.persistence.dataStores }}
 apiVersion: v1
@@ -53,5 +53,6 @@ spec:
     volumeAttributes:
       path: {{ $value.aws.volumePath }}
   {{- end }}
+{{- end }}
 ---
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -201,5 +201,11 @@ global:
         volumeHandle: null
         volumePath: "/"
 
+
+    # global.persistence.statefulset.pv.enabled: Global variable that controls the generation of statefulset pv/pvc(s)
+    statefulset:
+      pv:
+        enabled: true
+
   # must be last for file to be appended with addresses
   globalIPAddresses:


### PR DESCRIPTION
Added a global flag that can be overwritten that will exempt the pv/pvc from being re-built.  Made changes to the helm charts and the readme file.  Did not change the Jenkins file as it did not seem to be relevant. 